### PR TITLE
Enabled detection of probe requests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,3 @@ Things to do before you start:
 - The mqtt topic is Sniffer/#
 
 You find a sample Node-Red flow. Just copy-paste the raw file into your Node-Red
-
-
-# Dependencies
-
-Install using the Library Manager in Arduino:
-- ESP8266
-- ArduinoJson
-- PubSubClient
-

--- a/README.md
+++ b/README.md
@@ -9,3 +9,12 @@ Things to do before you start:
 - The mqtt topic is Sniffer/#
 
 You find a sample Node-Red flow. Just copy-paste the raw file into your Node-Red
+
+
+# Dependencies
+
+Install using the Library Manager in Arduino:
+- ESP8266
+- ArduinoJson
+- PubSubClient
+

--- a/WiFi_Sniffer/structures.h
+++ b/WiFi_Sniffer/structures.h
@@ -135,6 +135,19 @@ struct clientinfo parse_data(uint8_t *frame, uint16_t framelen, signed rssi, uns
   return ci;
 }
 
+struct clientinfo parse_probe(uint8_t *frame, uint16_t framelen, signed rssi)
+{
+  struct clientinfo pi;
+  pi.channel = -1;
+  pi.err = 0;
+  pi.rssi = rssi;
+  struct sniffer_buf2 *sniffer = (struct sniffer_buf2*) frame;
+  memset(pi.bssid,0xFF,ETH_MAC_LEN);
+  memcpy(pi.station, frame + 10, ETH_MAC_LEN);
+  if ((pi.station[0] & 2) == 2) pi.channel=-2; // Randomised MAC !
+  return pi;
+}
+
 struct beaconinfo parse_beacon(uint8_t *frame, uint16_t framelen, signed rssi)
 {
   struct beaconinfo bi;


### PR DESCRIPTION
Probe requests are stored in the clients_known array just like associated clients.
To differentiate from associated clients, the channel is set to -1 for probe requests, or -2 if the request is from a MAC address marked as "locally administered", meaning that it is most likely a randomised MAC address.
If probe requests from randomised MAC addresses are unwanted, uncomment line 84 in functions.h

Please note, I have not testet the MQTT output, but the output to serial monitor looks correct.